### PR TITLE
Some little improvements

### DIFF
--- a/app/views/whining_mailer/whining.text.html.rhtml
+++ b/app/views/whining_mailer/whining.text.html.rhtml
@@ -9,7 +9,7 @@ end
 
 <ul>
 <% @issues.each do |issue| -%>
-    <li><%=h issue.project%> - <%=link_to("#{issue.tracker} ##{issue.id}", :controller => 'issues', :action => 'show', :id => issue, :only_path => false)%>: <%=h issue.subject %></li>
+    <li><%=h issue.project%> - <%=link_to("#{issue.tracker} ##{issue.id}", :controller => 'issues', :action => 'show', :id => issue, :only_path => false)%> : <%=h issue.subject %> - <%=h l(:label_update) %> <%=h issue.updated_on.strftime("d-%m-%Y") %></li>
 <% end -%>
 </ul>
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -2,6 +2,7 @@ ca:
 # Catalan strings go here
   mail_body_whining: "{{count}} assumpte(s) que li han assignat, no s'han actualitzat en els ultims {{days}} dies:"
   mail_subject_whining: "{{count}} assumpte(s) no actualitzat en els ultims {{days}} dies"
+  label_update: "actualitzat en"
   whining_whine_when: "Recordar (segon prioritat) despres de"
   days: "dies"
   default: "Per defecte"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,6 +2,7 @@ de:
 # German strings go here
   mail_body_whining: "{{count}} Ticket(s), die Ihnen zugwiesen sind, wurden in den letzten {{days}} Tagen nicht aktualisiert"
   mail_subject_whining: "{{count}} Tickets(s) wurden nicht aktualisiert."
+  label_update: "was updated on"
   whining_whine_when: "Wann weinen?"
   days: "Tage"
   default: "Default"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
 # English strings go here
   mail_body_whining: "{{count}} issue(s) that are assigned to you haven't been updated in the last {{days}} days:"
   mail_subject_whining: "{{count}} issue(s) not updated in the last {{days}} days"
+  label_update: "was updated on"
   whining_whine_when: "Whine after"
   days: "days"
   default: "Default"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,6 +2,7 @@ es:
 # Spanish strings go here
   mail_body_whining: "{{count}} peticione(s) asignada(s) a usted, no se ha(n) actualizado en los ultimos {{days}} dias:"
   mail_subject_whining: "{{count}} peticione(s) no actualizadas en los ultimos {{days}} dias"
+  label_update: "actualizado en"
   whining_whine_when: "Recordar (segun prioridad) despues de"
   days: "dias"
   default: "Por defecto"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,6 +4,7 @@ fr:
 # Released under GPL2 licence
   mail_body_whining: "{{count}} tache(s) qui vous sont assignees et que vous n'avez pas mis a jour ces {{days}} derniers jours:"
   mail_subject_whining: "{{count}} tache(s) non mise(s) a jour ces derniers {{days}} jours"
+  label_update: "was updated on"
   whining_whine_when: "Pleurnicher après"
   days: "jours"
   default: "Par défaut"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,6 +2,7 @@ it:
 # Le stringhe italiane vanno qui
   mail_body_whining: "{{count}} segnalazione/i assegnate a te non sono state aggiornate negli ultimi {{days}} giorni:"
   mail_subject_whining: "{{count}} segnalazione/i non aggiornate negli ultimi {{days}} giorni"
+  label_update: "was updated on"
   whining_whine_when: "Lamentele dopo"
   days: "giorni"
   default: "Default"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,4 @@ ja:
 # Japanese strings go here
   mail_body_whining: "あなたが担当のチケット {{count}} つが過去 {{days}} 日間更新されていません:"
   mail_subject_whining: "チケット {{count}} つが過去 {{days}} 日間ノータッチ"
+label_update: "was updated on"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,6 +2,7 @@ nl:
 # Dutch strings go here
   mail_body_whining: "{{count}} issue(s) die aan u zijn toegekend zijn niet gewijzigd in de laatste {{days}} dagen:"
   mail_subject_whining: "{{count}} issue(s) niet gewijzigd in de laatste {{days}} dagen"
+  label_update: "was updated on"
   whining_whine_when: "Zeuren na"
   days: "dagen"
   default: "Standaard"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -2,6 +2,7 @@ pt:
 # Portuguese strings go here
   mail_body_whining: "{{count}} tarefa(s) atribuidas a si não foram actualizadas nos últimos {{days}} dias:"
   mail_subject_whining: "{{count}} tarefa(s) não actualizadas nos últimos {{days}} dias"
+  label_update: "foi atualizado"
   whining_whine_when: "Lembrar após"
   days: "dias"
   default: "Default"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -2,6 +2,7 @@ ru:
 # Russians strings go here
   mail_body_whining: "В {{count}} назначенных Вам задач, не было обновлений в течении {{days}} суток:"
   mail_subject_whining: "{{count}} задач не обновлялись за последние {{days}} суток"
+  label_update: "was updated on"
   whining_whine_when: "Жалуюсь после "
   days: "дней"
   default: "По умолчанию"


### PR DESCRIPTION
Hi Chantra,

I've added a field to enable the translation of "was updated on" at the email, so each language file has the new field to be translated (already done in ca, es, en and pt). Also I've changed a little bit the date format of the update date in order to shrink a little each row listed at the email (for bb users like me is much better).
I hope helping improve this redmine plugin.
BR,
Daniel
